### PR TITLE
more minor changes

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1215,11 +1215,12 @@ impl<'a> Scanner<'a> {
         // look for labels before the keyword
         self.read_labels();
 
-        let mut stype = Eof;
         let kwtok = self.get();
-        if !kwtok.is_null() {
+        let stype = if kwtok.is_null() {
+            Eof
+        } else {
             let kwtok_ref = kwtok.as_ref(self.buffer);
-            stype = if kwtok_ref.len() == 2 && kwtok_ref[0] == b'$' {
+            if kwtok_ref.len() == 2 && kwtok_ref[0] == b'$' {
                 match kwtok_ref[1] {
                     b'[' => FileInclude,
                     b'a' => Axiom,
@@ -1235,10 +1236,10 @@ impl<'a> Scanner<'a> {
                 }
             } else {
                 Invalid
-            };
-            if stype == Invalid {
-                self.diag(Diagnostic::UnknownKeyword(kwtok));
             }
+        };
+        if stype == Invalid {
+            self.diag(Diagnostic::UnknownKeyword(kwtok));
         }
         self.invalidated = false;
 
@@ -1280,9 +1281,11 @@ impl<'a> Scanner<'a> {
             _ => {}
         }
 
-        if self.invalidated {
-            stype = Invalid;
-        }
+        let stype = if self.invalidated {
+            Invalid
+        } else {
+            stype
+        };
 
         self.out_statement(stype, label)
     }

--- a/src/scopeck.rs
+++ b/src/scopeck.rs
@@ -665,19 +665,17 @@ fn scope_check_dv<'a>(state: &mut ScopeState<'a>, sref: StatementRef<'a>) {
         return;
     }
 
-    if !sref.in_group() {
-        // we need to do validity checking on global $d _somewhere_, and that
-        // happens to be here, but the knowledge of the $d is handled by nameck
-        // in that case and we need to not duplicate it
-        return;
+    // we need to do validity checking on global $d _somewhere_, and that
+    // happens to be here, but the knowledge of the $d is handled by nameck
+    // in that case and we need to not duplicate it
+    if sref.in_group() {
+        // record the $d in our local storage, will be deleted in
+        // construct_full_frame when it's no longer in scope
+        state.local_dv.push(LocalDvInfo {
+            valid: sref.scope_range(),
+            vars: vars,
+        });
     }
-
-    // record the $d in our local storage, will be deleted in
-    // construct_full_frame when it's no longer in scope
-    state.local_dv.push(LocalDvInfo {
-        valid: sref.scope_range(),
-        vars: vars,
-    });
 }
 
 fn scope_check_essential<'a>(state: &mut ScopeState<'a>, sref: StatementRef<'a>) {


### PR DESCRIPTION
- database.rs: fewer type ascriptions, simplify `Promise::join`
- parser.rs: make `stype` immutable
- scopeck.rs: tail is small enough that an early return is overkill (also I don't like negated tests)
