### PR TITLE
Remove unnecessary clone() calls

### DIFF
--- a/src/segment_set.rs
+++ b/src/segment_set.rs
@@ -319,7 +319,7 @@ impl SegmentSet {
             // make a wrapper promise to build the proper file result.  this
             // does _not_ run on a worker thread
             Promise::join(promises)
-                .map(move |srlist| FileSR(timestamp.map(move |s| (path.clone(), s)), srlist))
+                .map(move |srlist| FileSR(timestamp.map(move |s| (path, s)), srlist))
         }
 
         // read a file from disk (intercessions have already been checked, but
@@ -445,7 +445,7 @@ impl SegmentSet {
         };
 
         // parse and recursively incorporate the initial file
-        let isegs = read_and_parse(&mut state, path.clone());
+        let isegs = read_and_parse(&mut state, path);
         let isegs = flat(&mut state, isegs.wait());
         recurse(&mut state, isegs);
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -78,7 +78,7 @@ pub fn fast_extend<T: Copy>(vec: &mut Vec<T>, other: &[T]) {
 /// Appends a slice of a byte vector to the end of the same vector.
 #[inline(always)]
 pub fn copy_portion(vec: &mut Vec<u8>, from: Range<usize>) {
-    let Range { start: copy_start, end: copy_end } = from.clone();
+    let Range { start: copy_start, end: copy_end } = from;
     &vec[from]; // for the bounds check
     unsafe {
         let copy_len = copy_end - copy_start;

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -658,7 +658,7 @@ pub fn verify(result: &mut VerifyResult,
             if let Some(old_res) = old_res_o {
                 if old_res.scope_usage.valid(&nset, &scope) &&
                    ptr_eq::<Segment>(&old_res.source, &sref) {
-                    return (id, old_res.clone());
+                    return (id, old_res);
                 }
             }
             if segments2.options.trace_recalc {


### PR DESCRIPTION
Remove unnecessary clone() calls; they take more time & removing them
makes the code simpler.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>