### PR TITLE
Add simple CI pipeline via GitHub actions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, windows-latest, macOS-latest]
         rust: [stable] # [stable, nightly]
     # needs: skip_dups
     # if: ${{ needs.skip_dups.outputs.should_skip != 'true' }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable, nightly]
     needs: skip_dups
     if: ${{ needs.skip_dups.outputs.should_skip != 'true' }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,41 @@
+name: verify
+on: [push, pull_request, workflow_dispatch]
+
+# Verify software.
+
+jobs:
+  ###########################################################
+  skip_dups:
+    name: Check for duplicate jobs to avoid duplication
+    # continue-on-error: true # Uncomment once integration is finished
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          github_token: ${{ github.token }}
+          paths_ignore: '["**/README.md", "**/docs/**"]'
+
+  ###########################################################
+  test:
+    name: Rebuild and test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:: [ubuntu-latest, windows-latest, macOS-latest]
+        rust: [stable, nightly]
+    needs: skip_dups
+    if: ${{ needs.skip_dups.outputs.should_skip != 'true' }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install rust
+        uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: ${{ matrix.rust }}
+      # TODO: Add more static tests, perhaps eventually fail on warnings
+      # (or disable those warnings, preferably as specifically as we can).
+      - name: Run tests
+        run: cargo test --verbose

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable] # [stable, nightly]
-    needs: skip_dups
+    # needs: skip_dups
     # if: ${{ needs.skip_dups.outputs.should_skip != 'true' }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,20 +4,22 @@ on: [push, pull_request, workflow_dispatch]
 # Verify software.
 
 jobs:
+  # Skipping duplicate jobs doesn't work well with matrix (!!),
+  # so we'll just do excess work.
   ###########################################################
-  skip_dups:
-    name: Check for duplicate jobs to avoid duplication
-    # continue-on-error: true # Uncomment once integration is finished
-    runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          github_token: ${{ github.token }}
-          paths_ignore: '["**/README.md", "**/docs/**"]'
+  #    skip_dups:
+  #      name: Check for duplicate jobs to avoid duplication
+  #      # continue-on-error: true # Uncomment once integration is finished
+  #      runs-on: ubuntu-latest
+  #      # Map a step output to a job output
+  #      outputs:
+  #        should_skip: ${{ steps.skip_check.outputs.should_skip }}
+  #      steps:
+  #        - id: skip_check
+  #          uses: fkirc/skip-duplicate-actions@master
+  #          with:
+  #            github_token: ${{ github.token }}
+  #            paths_ignore: '["**/README.md", "**/docs/**"]'
 
   ###########################################################
   test:
@@ -26,9 +28,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [stable, nightly]
+        rust: stable # [stable, nightly]
     needs: skip_dups
-    if: ${{ needs.skip_dups.outputs.should_skip != 'true' }}
+    # if: ${{ needs.skip_dups.outputs.should_skip != 'true' }}
     steps:
       - uses: actions/checkout@v2
       - name: Install rust

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: stable # [stable, nightly]
+        rust: [stable] # [stable, nightly]
     needs: skip_dups
     # if: ${{ needs.skip_dups.outputs.should_skip != 'true' }}
     steps:


### PR DESCRIPTION
Create a simple CI pipeline via GitHub actions.
This does a basic "cargo test" on several different environments
and two different versions of Rust. Eventually more checks can
be added.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>